### PR TITLE
[0.3.0] - 2021-04-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.3.0] - 2021-04-01
 ### Added
 - support for chain contract update
 - support for block reverts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"


### PR DESCRIPTION
### Added
- support for chain contract update
- support for block reverts
  
### Changed
- sync data when root is available instead of waiting for next block
- update toolbox to `^0.9.0`