### PR TITLE
fix: check if validator location exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.3.2] - 2021-05-03
+### Fixed
+- Mark block as failed when validator can't be reached (not exists)
+
 ## [0.3.1] - 2021-05-03
 ### Added
 - Add new Production git workflow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/services/LeavesSynchronizer.ts
+++ b/src/services/LeavesSynchronizer.ts
@@ -26,6 +26,10 @@ class LeavesSynchronizer {
       const voterId = block.voters[voterIndex];
       const validator = await this.validatorRegistryContract.validators(voterId);
       const location = validator['location'];
+      if (!location) {
+        continue;
+      }
+
       const url = new URL(`${location}/blocks/height/${block.height}`);
       this.logger.info(`Resolving leaves from: ${url}`);
       const response = await axios.get<{ data: BlockFromPegasus }>(url.toString());


### PR DESCRIPTION
## [0.3.2] - 2021-05-03
### Fixed
- Mark block as failed when validator can't be reached (not exists)


```
info: Syncing finished side block with votes: [["0xDc3eBc37DA53A644D67E5E3b5BA4EEF88D969d5C","1000000000000000000"],["0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0","2000000000000000000"]]
info: Block 566 has finished: [object Object] with status: new
node:internal/process/promises:245
          triggerUncaughtException(err, true /* fromPromise */);
          ^

TypeError [ERR_INVALID_URL]: Invalid URL: /blocks/height/563
    at new NodeError (node:internal/errors:329:5)
    at onParseError (node:internal/url:537:9)
    at new URL (node:internal/url:613:5)
    at LeavesSynchronizer.<anonymous> (/home/runner/app/dist/services/LeavesSynchronizer.js:45:29)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/app/dist/services/LeavesSynchronizer.js:14:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5) {
  input: '/blocks/height/563',
  code: 'ERR_INVALID_URL'
}

```