### PR TITLE
feat: hide proofs when there is no apiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- hide proofs when user does not provide api key
 
 ## [4.10.0] - 2022-02-23
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanctuary",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sanctuary",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "dependencies": {
         "@influxdata/influxdb-client": "^1.14.0",
         "@influxdata/influxdb-client-apis": "^1.14.0",

--- a/src/controllers/ApiKeysController.ts
+++ b/src/controllers/ApiKeysController.ts
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 import Project from '../models/Project';
 import ApiKey from '../models/ApiKey';
 import cryptoRandomString from 'crypto-random-string';
-import { AuthenticationMiddleware } from '../middleware/AuthenticationMiddleware';
+import { ProtectedMiddleware } from '../middleware/ProtectedMiddleware';
 import { translateAuth0UserId } from '../lib/translateAuth0UserId';
 
 interface ICreateApiKeyReqBody {
@@ -26,10 +26,10 @@ interface IEditApiKeyReqBody {
 class ApiKeysController {
   router: express.Router;
 
-  constructor(@inject(AuthenticationMiddleware) authenticationMiddleware: AuthenticationMiddleware) {
+  constructor(@inject(ProtectedMiddleware) protectedMiddleware: ProtectedMiddleware) {
     this.router = express
       .Router()
-      .use(authenticationMiddleware.apply)
+      .use(protectedMiddleware.apply)
       .post('/', this.create)
       .get('/', this.index)
       .delete('/:id', this.delete)

--- a/src/controllers/MetricsController.ts
+++ b/src/controllers/MetricsController.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 import express, { Request, Response } from 'express';
-import { AuthenticationMiddleware } from '../middleware/AuthenticationMiddleware';
+import { RestrictedMiddleware } from '../middleware/RestrictedMiddleware';
 import { MetricsRepository } from '../repositories/MetricsRepository';
 import { getDateAtMidnight } from '../utils/time';
 import isValid from 'date-fns/isValid';
@@ -10,8 +10,8 @@ class MetricsController {
   @inject(MetricsRepository) metricsRepository!: MetricsRepository;
   router: express.Router;
 
-  constructor(@inject(AuthenticationMiddleware) authenticationMiddleware: AuthenticationMiddleware) {
-    this.router = express.Router().use(authenticationMiddleware.restrictAccess).get('/voters', this.getVotersCount);
+  constructor(@inject(RestrictedMiddleware) restrictedMiddleware: RestrictedMiddleware) {
+    this.router = express.Router().use(restrictedMiddleware.apply).get('/voters', this.getVotersCount);
   }
 
   private getVotersCount = async (request: Request, response: Response): Promise<void> => {

--- a/src/controllers/ProfileController.ts
+++ b/src/controllers/ProfileController.ts
@@ -1,6 +1,6 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import { NextFunction, Request, Response, Router } from 'express';
-import { AuthenticationMiddleware } from '../middleware/AuthenticationMiddleware';
+import { ProtectedMiddleware } from '../middleware/ProtectedMiddleware';
 import { UserNotFoundError, UserRepository, UserUpdateError } from '../repositories/UserRepository';
 import { MetricsMiddleware } from '../middleware/MetricsMiddleware';
 import { Logger } from 'winston';
@@ -10,8 +10,8 @@ export class ProfileController {
   @inject('Logger')
   private logger!: Logger;
 
-  @inject(AuthenticationMiddleware)
-  private authenticationMiddleware!: AuthenticationMiddleware;
+  @inject(ProtectedMiddleware)
+  private protectedMiddleware!: ProtectedMiddleware;
 
   @inject(MetricsMiddleware)
   private metricsMiddleware!: MetricsMiddleware;
@@ -26,7 +26,7 @@ export class ProfileController {
     this.router = Router();
 
     this.router
-      .use(this.authenticationMiddleware.apply)
+      .use(this.protectedMiddleware.apply)
       .get('/', this.show)
       .put('/', this.update)
       .patch('/', this.update)

--- a/src/controllers/ProjectsController.ts
+++ b/src/controllers/ProjectsController.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'inversify';
 import express, { Request, Response } from 'express';
 import mongoose from 'mongoose';
 import Project from '../models/Project';
-import { AuthenticationMiddleware } from '../middleware/AuthenticationMiddleware';
+import { ProtectedMiddleware } from '../middleware/ProtectedMiddleware';
 import { translateAuth0UserId } from '../lib/translateAuth0UserId';
 
 interface ICreateProjectReqBody {
@@ -13,10 +13,10 @@ interface ICreateProjectReqBody {
 class ProjectsController {
   router: express.Router;
 
-  constructor(@inject(AuthenticationMiddleware) authenticationMiddleware: AuthenticationMiddleware) {
+  constructor(@inject(ProtectedMiddleware) protectedMiddleware: ProtectedMiddleware) {
     this.router = express
       .Router()
-      .use(authenticationMiddleware.apply)
+      .use(protectedMiddleware.apply)
       .post('/', this.create)
       .get('/', this.index)
       .delete('/:id', this.delete);

--- a/src/controllers/ProofsController.ts
+++ b/src/controllers/ProofsController.ts
@@ -3,7 +3,6 @@ import express, { Request, Response } from 'express';
 import Leaf from '../models/Leaf';
 import { BlockStatus } from '../types/blocks';
 import StatsdClient from 'statsd-client';
-import { AuthenticationMiddleware } from '../middleware/AuthenticationMiddleware';
 import Settings from '../types/Settings';
 import { BlockRepository } from '../repositories/BlockRepository';
 
@@ -20,8 +19,8 @@ class ProofsController {
 
   router: express.Router;
 
-  constructor(@inject(AuthenticationMiddleware) authenticationMiddleware: AuthenticationMiddleware) {
-    this.router = express.Router().use(authenticationMiddleware.apply).get('/', this.index);
+  constructor() {
+    this.router = express.Router().get('/', this.index);
   }
 
   index = async (request: Request, response: Response): Promise<void> => {

--- a/src/controllers/UsageMetricsController.ts
+++ b/src/controllers/UsageMetricsController.ts
@@ -3,15 +3,15 @@ import express, { Request, Response } from 'express';
 import Project from '../models/Project';
 import ApiKey from '../models/ApiKey';
 import UsageMetricsRepository from '../services/analytics/UsageMetricsRepository';
-import { AuthenticationMiddleware } from '../middleware/AuthenticationMiddleware';
+import { ProtectedMiddleware } from '../middleware/ProtectedMiddleware';
 import { translateAuth0UserId } from '../lib/translateAuth0UserId';
 
 @injectable()
 class UsageMetricsController {
   router: express.Router;
 
-  constructor(@inject(AuthenticationMiddleware) authenticationMiddleware: AuthenticationMiddleware) {
-    this.router = express.Router().use(authenticationMiddleware.apply).get('/', this.index);
+  constructor(@inject(ProtectedMiddleware) protectedMiddleware: ProtectedMiddleware) {
+    this.router = express.Router().use(protectedMiddleware.apply).get('/', this.index);
   }
 
   index = async (request: Request, response: Response): Promise<void> => {

--- a/src/middleware/ProtectedMiddleware.ts
+++ b/src/middleware/ProtectedMiddleware.ts
@@ -1,0 +1,31 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { Request, Response, NextFunction } from 'express';
+import { RequestHandler } from 'express-jwt';
+
+import { AuthenticationMiddleware } from './AuthenticationMiddleware';
+import { ProjectAuthUtils } from '../services/ProjectAuthUtils';
+
+@injectable()
+export class ProtectedMiddleware extends AuthenticationMiddleware {
+  @inject(ProjectAuthUtils)
+  private projectAuthenticator: ProjectAuthUtils;
+
+  private userAuthenticator!: RequestHandler;
+
+  @postConstruct()
+  setup(): void {
+    this.userAuthenticator = this.setupRequestHandler();
+  }
+
+  apply = async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+    const projectAuthentication = await this.projectAuthenticator.verifyApiKey(request);
+
+    if (projectAuthentication?.apiKey) {
+      request.params['currentProjectId'] = projectAuthentication.apiKey.projectId; //TODO: deprecate
+      request.project = { id: projectAuthentication.apiKey.projectId };
+      next();
+    } else {
+      this.userAuthenticator(request, response, next);
+    }
+  };
+}

--- a/src/middleware/RestrictedMiddleware.ts
+++ b/src/middleware/RestrictedMiddleware.ts
@@ -1,0 +1,35 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { Request, Response, NextFunction } from 'express';
+import { RequestHandler } from 'express-jwt';
+
+import { AuthenticationMiddleware } from './AuthenticationMiddleware';
+import { ProjectAuthUtils } from '../services/ProjectAuthUtils';
+
+@injectable()
+export class RestrictedMiddleware extends AuthenticationMiddleware {
+  @inject(ProjectAuthUtils)
+  private projectAuthenticator: ProjectAuthUtils;
+
+  private userAuthenticator!: RequestHandler;
+
+  @postConstruct()
+  setup(): void {
+    this.userAuthenticator = this.setupRequestHandler();
+  }
+
+  apply = async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+    const authorizationKey = this.getAuthorizationHeader(request);
+
+    if (!authorizationKey) {
+      this.throwUnauthorizedError();
+    }
+
+    const apiKey = this.projectAuthenticator.verifyRestrictApiKey(authorizationKey);
+
+    if (apiKey?.apiKey) {
+      next();
+    } else {
+      this.userAuthenticator(request, response, next);
+    }
+  };
+}

--- a/src/middleware/UnprotectedMiddleware.ts
+++ b/src/middleware/UnprotectedMiddleware.ts
@@ -1,0 +1,32 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { Request, Response, NextFunction } from 'express';
+import { RequestHandler } from 'express-jwt';
+
+import { AuthenticationMiddleware } from './AuthenticationMiddleware';
+import { ProjectAuthUtils } from '../services/ProjectAuthUtils';
+
+@injectable()
+export class UnprotectedMiddleware extends AuthenticationMiddleware {
+  @inject(ProjectAuthUtils)
+  private projectAuthenticator: ProjectAuthUtils;
+
+  private userAuthenticator!: RequestHandler;
+
+  @postConstruct()
+  setup(): void {
+    this.userAuthenticator = this.setupRequestHandler(false);
+  }
+
+  apply = async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+    const projectAuthentication = await this.projectAuthenticator.verifyApiKey(request);
+
+    if (projectAuthentication?.apiKey) {
+      response.locals.isAuthorized = true;
+      request.params['currentProjectId'] = projectAuthentication.apiKey.projectId; //TODO: deprecate
+      request.project = { id: projectAuthentication.apiKey.projectId };
+      next();
+    } else {
+      this.userAuthenticator(request, response, next);
+    }
+  };
+}

--- a/src/services/ProjectAuthUtils.ts
+++ b/src/services/ProjectAuthUtils.ts
@@ -28,13 +28,7 @@ export class ProjectAuthUtils {
     return apiKeyVerificationResult;
   }
 
-  verifyRestrictApiKey(request: Request): { apiKey?: string; errorMessage?: string } {
-    const {
-      headers: { authorization: authorizationHeader },
-    } = request;
-
-    const apiKey = authorizationHeader.replace('Bearer ', '');
-
+  verifyRestrictApiKey(apiKey: string): { apiKey?: string; errorMessage?: string } {
     if (apiKey !== this.settings.api.restrict.apiKey) {
       return { errorMessage: 'Unknown API key' };
     }

--- a/test/e2e/apiKeys/createApiKey.e2e.ts
+++ b/test/e2e/apiKeys/createApiKey.e2e.ts
@@ -40,7 +40,7 @@ describe('createApiKey', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).post('/api-keys').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).post('/api-keys').set('Authorization', 'Bearer wrongBearer');
         expect(response.status).to.eq(401);
       });
     });

--- a/test/e2e/apiKeys/deleteApiKey.e2e.ts
+++ b/test/e2e/apiKeys/deleteApiKey.e2e.ts
@@ -41,7 +41,7 @@ describe('deleteApiKey', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).delete('/api-keys/API_KEY_ID').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).delete('/api-keys/API_KEY_ID').set('Authorization', 'Bearer wrongBearer');
         expect(response.status).to.eq(401);
       });
     });

--- a/test/e2e/apiKeys/getApiKey.e2e.ts
+++ b/test/e2e/apiKeys/getApiKey.e2e.ts
@@ -43,7 +43,7 @@ describe('getApiKey', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).get('/api-keys').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).get('/api-keys').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/apiKeys/updateApiKey.e2e.ts
+++ b/test/e2e/apiKeys/updateApiKey.e2e.ts
@@ -43,7 +43,7 @@ describe('updateApiKey', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).put('/api-keys/SOME_KEY').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).put('/api-keys/SOME_KEY').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/blocks/getForeignBlocks.e2e.ts
+++ b/test/e2e/blocks/getForeignBlocks.e2e.ts
@@ -40,16 +40,16 @@ describe('getForeignBlocks', () => {
 
   describe('GET /blocks:chainId', () => {
     describe('when no bearer token is provided', () => {
-      it('responds with HTTP 401 Unauthorized', async () => {
+      it('responds with HTTP 200', async () => {
         const response = await request(app).get('/blocks?chainId=ethereum');
 
-        expect(response.status).to.eq(401);
+        expect(response.status).to.eq(200);
       });
     });
 
     describe('when an invalid bearer token is provided', () => {
-      it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).get('/blocks?chainId=ethereum').set('Authorization', 'Bearer wrgonBearer');
+      it('responds with HTTP 401', async () => {
+        const response = await request(app).get('/blocks?chainId=ethereum').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });
@@ -116,20 +116,20 @@ describe('getForeignBlocks', () => {
     });
 
     describe('when no bearer token is provided', () => {
-      it('responds with HTTP 401 Unauthorized', async () => {
+      it('responds with HTTP 200', async () => {
         const response = await request(app).get(
           `/blocks/${foreignBlock.blockId}?chainId=${foreignBlock.foreignChainId}`
         );
 
-        expect(response.status).to.eq(401);
+        expect(response.status).to.eq(200);
       });
     });
 
     describe('when an invalid bearer token is provided', () => {
-      it('responds with HTTP 401 Unauthorized', async () => {
+      it('responds with HTTP 401', async () => {
         const response = await request(app)
           .get(`/blocks/${foreignBlock.blockId}?chainId=${foreignBlock.foreignChainId}`)
-          .set('Authorization', 'Bearer wrgonBearer');
+          .set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/metrics/metrics.e2e.ts
+++ b/test/e2e/metrics/metrics.e2e.ts
@@ -40,7 +40,7 @@ describe('metrics', () => {
 
       describe('when an invalid bearer token is provided', () => {
         it('responds with HTTP 401 Unauthorized', async () => {
-          const response = await request(app).get('/metrics/voters').set('Authorization', 'Bearer wrgonBearer');
+          const response = await request(app).get('/metrics/voters').set('Authorization', 'Bearer wrongBearer');
 
           expect(response.status).to.eq(401);
         });

--- a/test/e2e/profile/profile.e2e.ts
+++ b/test/e2e/profile/profile.e2e.ts
@@ -44,7 +44,7 @@ describe('profile', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).get('/profile').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).get('/profile').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });
@@ -99,7 +99,7 @@ describe('profile', () => {
         const response = await request(app)
           .put('/profile')
           .send({ email: 'new.email@example.com' })
-          .set('Authorization', 'Bearer wrgonBearer');
+          .set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/projects/createProject.e2e.ts
+++ b/test/e2e/projects/createProject.e2e.ts
@@ -41,7 +41,7 @@ describe('createProjects', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).post('/projects').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).post('/projects').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/projects/deleteProjects.e2e.ts
+++ b/test/e2e/projects/deleteProjects.e2e.ts
@@ -36,7 +36,7 @@ describe('deletingProjects', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).delete('/projects/1').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).delete('/projects/1').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/projects/getProjects.e2e.ts
+++ b/test/e2e/projects/getProjects.e2e.ts
@@ -37,7 +37,7 @@ describe('getProjects', () => {
 
     describe('when an invalid bearer token is provided', () => {
       it('responds with HTTP 401 Unauthorized', async () => {
-        const response = await request(app).get('/projects').set('Authorization', 'Bearer wrgonBearer');
+        const response = await request(app).get('/projects').set('Authorization', 'Bearer wrongBearer');
 
         expect(response.status).to.eq(401);
       });

--- a/test/e2e/proofs/getProofs.e2e.ts
+++ b/test/e2e/proofs/getProofs.e2e.ts
@@ -10,7 +10,7 @@ import Block, { IBlock } from '../../../src/models/Block';
 import Leaf, { ILeaf } from '../../../src/models/Leaf';
 import { inputForBlockModel } from '../../fixtures/inputForBlockModel';
 import { setupDatabase, teardownDatabase } from '../../helpers/databaseHelpers';
-import { setupJWKSMock, teardownTestUser, TestAuthHarness } from '../../helpers/authHelpers';
+import { teardownTestUser } from '../../helpers/authHelpers';
 import ForeignBlock, { IForeignBlock } from '../../../src/models/ForeignBlock';
 import { foreignBlockFactory } from '../../mocks/factories/foreignBlockFactory';
 import { blockFactory } from '../../mocks/factories/blockFactory';
@@ -20,7 +20,6 @@ import Server from '../../../src/lib/Server';
 describe('getProofs', () => {
   let container: Container;
   let app: Application;
-  let authHarness: TestAuthHarness;
 
   before(async () => {
     loadTestEnv();
@@ -36,139 +35,111 @@ describe('getProofs', () => {
   });
 
   describe('GET /proofs', () => {
-    describe('when an invalid bearer token is provided', () => {
-      it('responds with HTTP 401 Unauthorized when no bearer token is given', async () => {
-        const res = await request(app).get('/proofs');
+    afterEach(async () => {
+      await Promise.all([Block.deleteMany({}), Leaf.deleteMany({}), ForeignBlock.deleteMany({})]);
+    });
 
-        expect(res.status).to.eq(401);
-      });
+    describe('when finalized block found', () => {
+      it('returns valid response without leaves for the latest finalized block', async () => {
+        await Block.create([
+          { ...inputForBlockModel, _id: 'block::1', blockId: 1, status: 'new' },
+          { ...inputForBlockModel, _id: 'block::2', blockId: 2, status: 'finalized' },
+          { ...inputForBlockModel, _id: 'block::3', blockId: 3, status: 'failed' },
+          { ...inputForBlockModel, _id: 'block::4', blockId: 4, status: 'finalized' },
+        ]);
 
-      it('responds with HTTP 401 Unauthorized when no bearer token is wrong', async () => {
-        const res = await request(app).get('/proofs').set('Authorization', 'Bearer 123');
+        const proofsResponse = await request(app).get('/proofs');
 
-        expect(res.status).to.eq(401);
+        expect(proofsResponse.body.data.block).to.have.property('blockId', 4);
+        expect(proofsResponse.body.data.block).to.have.property('status', 'finalized');
+        expect(proofsResponse.body.data.keys).to.be.an('array').that.is.empty;
+        expect(proofsResponse.body.data.leaves).to.be.an('array').that.is.empty;
       });
     });
 
-    describe('when a valid bearer token is provided', () => {
+    describe('when no finalized block found', () => {
+      it('returns empty object', async () => {
+        await Block.create([
+          { ...inputForBlockModel, _id: 'block::1', blockId: 1, status: 'new' },
+          { ...inputForBlockModel, _id: 'block::2', blockId: 2, status: 'failed' },
+          { ...inputForBlockModel, _id: 'block::3', blockId: 3, status: 'failed' },
+          { ...inputForBlockModel, _id: 'block::4', blockId: 4, status: 'failed' },
+        ]);
+
+        const proofsResponse = await request(app).get('/proofs');
+
+        expect(proofsResponse.body.data).to.be.an('object').that.is.empty;
+      });
+    });
+  });
+
+  describe('GET /proofs?keys=<n>', () => {
+    it('returns latest block with leaves matching specified keys', async () => {
+      await Block.create([
+        { ...inputForBlockModel, _id: 'block::1', blockId: 1 },
+        { ...inputForBlockModel, _id: 'block::2', blockId: 2 },
+        { ...inputForBlockModel, _id: 'block::3', blockId: 3 },
+        { ...inputForBlockModel, _id: 'block::4', blockId: 4 },
+      ]);
+
+      await Leaf.create([
+        { _id: 'leaf::block::1::a', blockId: 1, key: 'a', value: '0x0', proof: [] },
+        { _id: 'leaf::block::2::a', blockId: 2, key: 'a', value: '0x0', proof: [] },
+        { _id: 'leaf::block::3::a', blockId: 3, key: 'a', value: '0x0', proof: [] },
+        { _id: 'leaf::block::4::a', blockId: 4, key: 'a', value: '0x0', proof: [] },
+        { _id: 'leaf::block::4::b', blockId: 4, key: 'b', value: '0x0', proof: [] },
+        { _id: 'leaf::block::4::c', blockId: 4, key: 'c', value: '0x0', proof: [] },
+      ]);
+
+      const proofsResponse = await request(app).get('/proofs?keys=a&keys=b');
+      const leafWithKeyA = proofsResponse.body.data.leaves.find((leaf: ILeaf) => leaf.key === 'a');
+      const leafWithKeyB = proofsResponse.body.data.leaves.find((leaf: ILeaf) => leaf.key === 'b');
+
+      expect(proofsResponse.status).to.be.eq(200);
+      expect(proofsResponse.body.data.block).to.have.property('blockId', 4);
+      expect(proofsResponse.body.data.keys).to.be.an('array').deep.eq(['a', 'b']);
+      expect(proofsResponse.body.data.leaves).to.be.an('array').with.lengthOf(2);
+
+      expect(leafWithKeyA).to.be.an('object').that.has.property('key', 'a');
+      expect(leafWithKeyA).to.be.an('object').that.has.property('blockId', 4);
+
+      expect(leafWithKeyB).to.be.an('object').that.has.property('key', 'b');
+      expect(leafWithKeyB).to.be.an('object').that.has.property('blockId', 4);
+    });
+  });
+
+  describe('GET /proofs?chainId=<n>', () => {
+    describe('when a foreign Chain ID is provided', () => {
+      let foreignBlock: IForeignBlock;
+      let block: IBlock;
+
+      const operation = async (chainId: string) => request(app).get(`/proofs?chainId=${chainId}`);
+
       beforeEach(async () => {
-        authHarness = await setupJWKSMock();
+        foreignBlock = new ForeignBlock(foreignBlockFactory.build());
+        block = new Block(
+          blockFactory.build({
+            status: BlockStatus.Finalized,
+            blockId: foreignBlock.blockId,
+          })
+        );
+        const nonFinalizedBlock = new Block(blockFactory.build({ blockId: 1000, status: BlockStatus.New }));
+
+        await foreignBlock.save();
+        await block.save();
+        await nonFinalizedBlock.save();
       });
 
       afterEach(async () => {
-        await authHarness.jwksMock.stop();
         await Promise.all([Block.deleteMany({}), Leaf.deleteMany({}), ForeignBlock.deleteMany({})]);
       });
 
-      describe('when finalized block found', () => {
-        it('returns valid response without leaves for the latest finalized block', async () => {
-          await Block.create([
-            { ...inputForBlockModel, _id: 'block::1', blockId: 1, status: 'new' },
-            { ...inputForBlockModel, _id: 'block::2', blockId: 2, status: 'finalized' },
-            { ...inputForBlockModel, _id: 'block::3', blockId: 3, status: 'failed' },
-            { ...inputForBlockModel, _id: 'block::4', blockId: 4, status: 'finalized' },
-          ]);
+      it('returns the latest finalized block', async () => {
+        const response = await operation('ethereum');
+        const subject = response.body.data.block;
 
-          const proofsResponse = await request(app)
-            .get('/proofs')
-            .set('Authorization', `Bearer ${authHarness.accessToken}`);
-
-          expect(proofsResponse.body.data.block).to.have.property('blockId', 4);
-          expect(proofsResponse.body.data.block).to.have.property('status', 'finalized');
-          expect(proofsResponse.body.data.keys).to.be.an('array').that.is.empty;
-          expect(proofsResponse.body.data.leaves).to.be.an('array').that.is.empty;
-        });
-      });
-
-      describe('when no finalized block found', () => {
-        it('returns empty object', async () => {
-          await Block.create([
-            { ...inputForBlockModel, _id: 'block::1', blockId: 1, status: 'new' },
-            { ...inputForBlockModel, _id: 'block::2', blockId: 2, status: 'failed' },
-            { ...inputForBlockModel, _id: 'block::3', blockId: 3, status: 'failed' },
-            { ...inputForBlockModel, _id: 'block::4', blockId: 4, status: 'failed' },
-          ]);
-
-          const proofsResponse = await request(app)
-            .get('/proofs')
-            .set('Authorization', `Bearer ${authHarness.accessToken}`);
-
-          expect(proofsResponse.body.data).to.be.an('object').that.is.empty;
-        });
-      });
-    });
-
-    describe('GET /proofs?keys=<n>', () => {
-      it('returns latest block with leaves matching specified keys', async () => {
-        await Block.create([
-          { ...inputForBlockModel, _id: 'block::1', blockId: 1 },
-          { ...inputForBlockModel, _id: 'block::2', blockId: 2 },
-          { ...inputForBlockModel, _id: 'block::3', blockId: 3 },
-          { ...inputForBlockModel, _id: 'block::4', blockId: 4 },
-        ]);
-
-        await Leaf.create([
-          { _id: 'leaf::block::1::a', blockId: 1, key: 'a', value: '0x0', proof: [] },
-          { _id: 'leaf::block::2::a', blockId: 2, key: 'a', value: '0x0', proof: [] },
-          { _id: 'leaf::block::3::a', blockId: 3, key: 'a', value: '0x0', proof: [] },
-          { _id: 'leaf::block::4::a', blockId: 4, key: 'a', value: '0x0', proof: [] },
-          { _id: 'leaf::block::4::b', blockId: 4, key: 'b', value: '0x0', proof: [] },
-          { _id: 'leaf::block::4::c', blockId: 4, key: 'c', value: '0x0', proof: [] },
-        ]);
-
-        const proofsResponse = await request(app)
-          .get('/proofs?keys=a&keys=b')
-          .set('Authorization', `Bearer ${authHarness.accessToken}`);
-        const leafWithKeyA = proofsResponse.body.data.leaves.find((leaf: ILeaf) => leaf.key === 'a');
-        const leafWithKeyB = proofsResponse.body.data.leaves.find((leaf: ILeaf) => leaf.key === 'b');
-
-        expect(proofsResponse.status).to.be.eq(200);
-        expect(proofsResponse.body.data.block).to.have.property('blockId', 4);
-        expect(proofsResponse.body.data.keys).to.be.an('array').deep.eq(['a', 'b']);
-        expect(proofsResponse.body.data.leaves).to.be.an('array').with.lengthOf(2);
-
-        expect(leafWithKeyA).to.be.an('object').that.has.property('key', 'a');
-        expect(leafWithKeyA).to.be.an('object').that.has.property('blockId', 4);
-
-        expect(leafWithKeyB).to.be.an('object').that.has.property('key', 'b');
-        expect(leafWithKeyB).to.be.an('object').that.has.property('blockId', 4);
-      });
-    });
-
-    describe('GET /proofs?chainId=<n>', () => {
-      describe('when a foreign Chain ID is provided', () => {
-        let foreignBlock: IForeignBlock;
-        let block: IBlock;
-
-        const operation = async (chainId: string) =>
-          request(app).get(`/proofs?chainId=${chainId}`).set('Authorization', `Bearer ${authHarness.accessToken}`);
-
-        beforeEach(async () => {
-          foreignBlock = new ForeignBlock(foreignBlockFactory.build());
-          block = new Block(
-            blockFactory.build({
-              status: BlockStatus.Finalized,
-              blockId: foreignBlock.blockId,
-            })
-          );
-          const nonFinalizedBlock = new Block(blockFactory.build({ blockId: 1000, status: BlockStatus.New }));
-
-          await foreignBlock.save();
-          await block.save();
-          await nonFinalizedBlock.save();
-        });
-
-        afterEach(async () => {
-          await Promise.all([Block.deleteMany({}), Leaf.deleteMany({}), ForeignBlock.deleteMany({})]);
-        });
-
-        it('returns the latest finalized block', async () => {
-          const response = await operation('ethereum');
-          const subject = response.body.data.block;
-
-          expect(subject._id).to.eq(block._id);
-          expect(subject.blockId).to.eq(block.blockId);
-        });
+        expect(subject._id).to.eq(block._id);
+        expect(subject.blockId).to.eq(block.blockId);
       });
     });
   });

--- a/test/mocks/factories/blockFactory.ts
+++ b/test/mocks/factories/blockFactory.ts
@@ -1,6 +1,10 @@
 import { Factory } from 'rosie';
 import { v4 } from 'uuid';
 
+import Block from '../../../src/models/Block';
+import Leaf from '../../../src/models/Leaf';
+import { inputForBlockModel } from '../../fixtures/inputForBlockModel';
+
 export const blockFactory = Factory.define('ForeignBlock')
   .attr('_id', () => v4())
   .sequence('blockId')
@@ -12,3 +16,21 @@ export const blockFactory = Factory.define('ForeignBlock')
   .attr('minter', 'MINTER')
   .attr('staked', 'STAKED')
   .attr('power', 'POWER');
+
+export const blockAndLeafFactory = async (): Promise<void> => {
+  await Block.create([
+    { ...inputForBlockModel, _id: 'block::1', blockId: 1 },
+    { ...inputForBlockModel, _id: 'block::2', blockId: 2 },
+    { ...inputForBlockModel, _id: 'block::3', blockId: 3 },
+    { ...inputForBlockModel, _id: 'block::4', blockId: 4 },
+  ]);
+
+  await Leaf.create([
+    { _id: 'leaf::block::1::a', blockId: 1, key: 'a', value: '0x0', proof: ['proof1'] },
+    { _id: 'leaf::block::1::b', blockId: 1, key: 'b', value: '0x0', proof: ['proof2'] },
+    { _id: 'leaf::block::2::a', blockId: 2, key: 'a', value: '0x0', proof: ['proof3'] },
+    { _id: 'leaf::block::2::b', blockId: 2, key: 'b', value: '0x0', proof: ['proof4'] },
+    { _id: 'leaf::block::3::a', blockId: 3, key: 'a', value: '0x0', proof: ['proof5'] },
+    { _id: 'leaf::block::4::a', blockId: 4, key: 'a', value: '0x0', proof: ['proof6'] },
+  ]);
+};


### PR DESCRIPTION
- make AuthenticationMiddleware abstract;
- create ProtectedMiddleware, UnprotectedMiddleware and RestrictedMiddleware;
- remove authentication to proofs/ endpoint;
- make blocks/ unprotected endpoint;