### PR TITLE
feature: Remove duplicated entries in /info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
 ### Changed
 - hide proofs when user does not provide api key
+### Fixed
+- Fixed an issue where status in the info endpoint would return duplicated entries
 
 ## [4.11.2] - 2022-03-09
 ### Fixed

--- a/src/contracts/BaseChainContract.ts
+++ b/src/contracts/BaseChainContract.ts
@@ -37,7 +37,16 @@ export abstract class BaseChainContract {
 
   async resolveStatus<T>(): Promise<T> {
     const chain = await this.resolveContract();
-    const status = await chain.contract.getStatus();
+    const chainContractStatus = await chain.contract.getStatus();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const status: any = {};
+
+    Object.keys(chainContractStatus).forEach((key) => {
+      if (Number.isNaN(Number(key))) {
+        status[key] = chainContractStatus[key];
+      }
+    });
+
     return { chainAddress: chain.contract.address, ...status };
   }
 

--- a/src/repositories/InfoRepository.ts
+++ b/src/repositories/InfoRepository.ts
@@ -44,11 +44,10 @@ export class InfoRepository {
     const status = await this.getStatus(chainContract);
     const contractRegistryAddress = this.getContractRegistryAddress(chainId);
     const chainContractAddress = this.getChainContractAddress(status);
-    let info: Info = { status, network, contractRegistryAddress, chainContractAddress, version, environment };
+    const info: Info = { status, network, contractRegistryAddress, chainContractAddress, version, environment };
 
     if (!chainId) {
-      const stakingBankAddress = await this.getStakingBankAddress();
-      info = { ...info, stakingBankAddress };
+      info.stakingBankAddress = await this.getStakingBankAddress();
     }
 
     return info;


### PR DESCRIPTION
### Fixed
- Fixed an issue where status in the info endpoint would return duplicated entries