### PR TITLE
feature: Add blockId to included L2D pairs report

### DIFF
--- a/src/services/BlockLeafCountReporter.ts
+++ b/src/services/BlockLeafCountReporter.ts
@@ -12,7 +12,7 @@ class BlockLeafCountReporter {
     const { blockId } = await Block.findOne({ status: BlockStatus.Finalized }).sort({ blockId: -1 });
     const leaves = await Leaf.find({ blockId });
 
-    this.statsDClient?.gauge('Layer2DataPairs', leaves.length);
+    this.statsDClient?.gauge('Layer2DataPairs', leaves.length, { blockId });
   }
 }
 


### PR DESCRIPTION
We need to set an alarm together with SRE to notify when we're the included pairs per block is under the threshold (i.e. too many discrepancies or such).
We just need to add the `blockId` to give more info on the report, as it's only reporting the environment and the amount of leaves.