### PR TITLE
feature: Add signature count endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added `GET: /signatures` to get participation rate of each voter in given interval of blocks
 
 ## [4.18.0] - 2022-05-05
 ### Added

--- a/src/config/setupDotenv.ts
+++ b/src/config/setupDotenv.ts
@@ -1,9 +1,3 @@
 import dotenv from 'dotenv';
 
-(async () => {
-  if (process.env.NODE_ENV === 'testing') {
-    await dotenv.config({ path: '.testing.env' });
-  } else {
-    await dotenv.config();
-  }
-})();
+dotenv.config({ path: process.env.NODE_ENV === 'testing' ? '.testing.env' : '.env' });

--- a/src/config/swagger-internal.json
+++ b/src/config/swagger-internal.json
@@ -360,6 +360,42 @@
         }
       }
     },
+    "/signatures": {
+      "get": {
+        "summary": "Returns the participation rate of voters in the latest given interval of blocks. If period is not defined, by default it will use today's date -1 hour.",
+        "tags": ["signatures"],
+        "parameters": [
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "The start date of period. This date is inclusive. Date format must be yyyy-mm-dd.",
+            "required": false,
+            "type": "string",
+            "example": "2022-01-01"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "The end date of period. This date is not inclusive. Date format must be yyyy-mm-dd.",
+            "required": false,
+            "type": "string",
+            "example": "2022-02-01"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of signatures with their respective participation rate on the latest blocks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Signatures"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/proofs": {
       "get": {
         "summary": "Returns the latest block height and proofs for a given set of leaf keys",
@@ -1513,6 +1549,22 @@
             "count": {
               "type": "number",
               "example": "12"
+            }
+          }
+        }
+      },
+      "Signatures": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "_id": {
+              "type": "string",
+              "example": "0xABCDEF123456"
+            },
+            "participation_rate": {
+              "type": "number",
+              "example": "91.2"
             }
           }
         }

--- a/src/config/swagger.json
+++ b/src/config/swagger.json
@@ -405,6 +405,42 @@
         }
       }
     },
+    "/signatures": {
+      "get": {
+        "summary": "Returns the participation rate of voters in the latest given interval of blocks. If period is not defined, by default it will use today's date -1 hour.",
+        "tags": ["signatures"],
+        "parameters": [
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "The start date of period. This date is inclusive. Date format must be yyyy-mm-dd.",
+            "required": false,
+            "type": "string",
+            "example": "2022-01-01"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "The end date of period. This date is not inclusive. Date format must be yyyy-mm-dd.",
+            "required": false,
+            "type": "string",
+            "example": "2022-02-01"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of signatures with their respective participation rate on the latest blocks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Signatures"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/proofs": {
       "get": {
         "summary": "Returns the latest block height and proofs for a given set of leaf keys",
@@ -777,6 +813,22 @@
             "count": {
               "type": "number",
               "example": "100"
+            }
+          }
+        }
+      },
+      "Signatures": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "_id": {
+              "type": "string",
+              "example": "0xABCDEF123456"
+            },
+            "participation_rate": {
+              "type": "number",
+              "example": "91.2"
             }
           }
         }

--- a/src/controllers/SignatureController.ts
+++ b/src/controllers/SignatureController.ts
@@ -1,0 +1,55 @@
+import { inject, injectable } from 'inversify';
+import express, { Request, Response } from 'express';
+import isValid from 'date-fns/isValid';
+import { subHours } from 'date-fns';
+
+import { MetricsQueries } from '../queries/MetricsQueries';
+import { TCount } from '../types/analytics/Metrics';
+import { BlockRepository, CountBlocksBetweenProps as Period } from '../repositories/BlockRepository';
+import { SignatureRate } from '../types/SignatureRate';
+
+@injectable()
+class SignatureController {
+  @inject(MetricsQueries) metricsQueries!: MetricsQueries;
+  @inject(BlockRepository) blockRepository!: BlockRepository;
+  router: express.Router;
+
+  constructor() {
+    this.router = express.Router().get('/', this.getSignatureCount);
+  }
+
+  private getSignatureCount = async (request: Request, response: Response): Promise<void> => {
+    const period = this.getDateOrDefault(<Period<string>>request.query);
+
+    const amountOfBlocks = await this.blockRepository.countBlocksFromPeriod(period);
+    const voters = await this.metricsQueries.getVotersCount(period);
+    const signatureRate = this.countSignatureRate(voters, amountOfBlocks);
+
+    response.send(signatureRate);
+  };
+
+  private getDateOrDefault = ({ startDate, endDate }: Period<string>): Period<Date> => {
+    const end = isValid(new Date(endDate)) ? new Date(endDate) : new Date();
+    const start = isValid(new Date(startDate)) ? new Date(startDate) : subHours(end, 1);
+
+    return {
+      startDate: start,
+      endDate: end,
+    };
+  };
+
+  private countSignatureRate = (voters: TCount[], numberOfBlocks: number): SignatureRate[] => {
+    return voters.map(({ _id, count }) => ({
+      _id,
+      participationRate: this.getRateInDecimal(count, numberOfBlocks),
+    }));
+  };
+
+  private getRateInDecimal = (signatures: number, blocks: number): number => {
+    const averageParticipationPerBlock = signatures / blocks;
+    const roundedRate = Math.round(averageParticipationPerBlock * 10000) / 100;
+    return roundedRate;
+  };
+}
+
+export default SignatureController;

--- a/src/lib/Server.ts
+++ b/src/lib/Server.ts
@@ -23,6 +23,7 @@ import { Logger } from 'winston';
 
 import swaggerDocument from '../config/swagger.json';
 import internalSwaggerDocument from '../config/swagger-internal.json';
+import SignatureController from '../controllers/SignatureController';
 
 @injectable()
 class Server {
@@ -44,7 +45,8 @@ class Server {
     @inject(ApiKeysController) apiKeyController: ApiKeysController,
     @inject(ProjectsController) projectsController: ProjectsController,
     @inject(InfoController) infoController: InfoController,
-    @inject(ProfileController) profileController: ProfileController
+    @inject(ProfileController) profileController: ProfileController,
+    @inject(SignatureController) signatureController: SignatureController
   ) {
     this.port = settings.port;
     this.logger = logger;
@@ -68,6 +70,7 @@ class Server {
       .use('/projects', projectsController.router)
       .use('/info', infoController.router)
       .use('/profile', profileController.router)
+      .use('/signatures', signatureController.router)
       .use(this.authErrorHandler)
       .use(this.generalErrorHandler);
 

--- a/src/types/SignatureRate.ts
+++ b/src/types/SignatureRate.ts
@@ -1,0 +1,4 @@
+export interface SignatureRate {
+  _id: string;
+  participationRate: number;
+}

--- a/test/e2e/signatures/signatures.e2e.ts
+++ b/test/e2e/signatures/signatures.e2e.ts
@@ -1,0 +1,103 @@
+import 'reflect-metadata';
+import { expect } from 'chai';
+import request from 'supertest';
+import { Application } from 'express';
+import { Container } from 'inversify';
+import { format, subDays } from 'date-fns';
+
+import Server from '../../../src/lib/Server';
+import { getContainer } from '../../../src/lib/getContainer';
+import { loadTestEnv } from '../../helpers';
+import { inputForBlockModel } from '../../fixtures/inputForBlockModel';
+import settings from '../../../src/config/settings';
+import { setupDatabase, teardownDatabase } from '../../helpers/databaseHelpers';
+import Block from '../../../src/models/Block';
+
+describe('signatures', () => {
+  let container: Container;
+  let app: Application;
+
+  before(async () => {
+    loadTestEnv();
+    await setupDatabase();
+
+    settings.api.restrict.apiKey = 'testToken';
+    container = getContainer();
+    container.rebind('Settings').toConstantValue(settings);
+    app = container.get(Server).app;
+
+    await Block.deleteMany();
+
+    await Block.create({ ...inputForBlockModel, _id: 'block::1', blockId: 1, dataTimestamp: new Date() });
+    await Block.create({ ...inputForBlockModel, _id: 'block::2', blockId: 2, dataTimestamp: subDays(new Date(), 1) });
+    await Block.create({ ...inputForBlockModel, _id: 'block::3', blockId: 3, dataTimestamp: subDays(new Date(), 2) });
+  });
+
+  after(async () => {
+    await teardownDatabase();
+  });
+
+  describe('GET /signatures', () => {
+    describe('when period query is invalid', () => {
+      describe('when period is not included in query', () => {
+        it('responds with signature rates on the default period', async () => {
+          const response = await request(app).get('/signatures');
+
+          expect(response.status).to.eq(200);
+          expect(response.body).to.be.an('array').with.length(1);
+        });
+      });
+
+      it('responds with signature rates on the default period', async () => {
+        const resource = '/signatures?startDate=invalid&endDate=invalid';
+        const response = await request(app).get(resource);
+
+        expect(response.status).to.eq(200);
+        expect(response.body).to.be.an('array').with.length(1);
+      });
+    });
+
+    describe('when period query is valid', () => {
+      it('responds with signature rates on the inserted period', async () => {
+        const period = {
+          startDate: format(subDays(new Date(), 10), 'yyyy-MM-dd'),
+          endDate: format(new Date(), 'yyyy-MM-dd'),
+        };
+
+        const resource = `/signatures?startDate=${period.startDate}&endDate=${period.endDate}`;
+        const response = await request(app).get(resource);
+
+        expect(response.status).to.eq(200);
+        expect(response.body).to.be.an('array').with.length(1);
+      });
+    });
+
+    describe('when there are no blocks in period', () => {
+      it('responds with an empty array', async () => {
+        const resource = '/signatures?startDate=1990-05-05&endDate=1990-05-06';
+        const response = await request(app).get(resource);
+
+        expect(response.status).to.eq(200);
+        expect(response.body).to.be.an('array').with.length(0);
+      });
+    });
+
+    describe('when there is more than one validator', () => {
+      it('responds with the signature rate of all participants', async () => {
+        await Block.create({
+          ...inputForBlockModel,
+          _id: 'block::4',
+          blockId: 4,
+          dataTimestamp: new Date(),
+          voters: ['0xB205324F4b6EB7Bc76f1964489b3769cfc7144A3'],
+          votes: new Map([['0xB205324F4b6EB7Bc76f1964489b3769cfc7144A3', '10000000000']]),
+        });
+
+        const response = await request(app).get('/signatures');
+
+        expect(response.status).to.eq(200);
+        expect(response.body).to.be.an('array').with.length(2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We need to add a new endpoint that returns the percentage of signatures from each voter in the latest blocks, given a period.
Period default should be one hour

The response should be something like this:
```json
[
  {
    "voter": "0xABC",
    "signatures": 38.5
  },
  {
    "voter": "0xDEF",
    "signatures": 85
  }
]
```
Where:
- `voter` is the current voter from the blocks
- `signature` is the percentage comparing the number of signatures / block. Must be a number between 0 and 100. One decimal case.
