### PR TITLE
feature: Cleanup `GET: /signatures` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Added `GET: /signatures` to get participation rate of each voter in given interval of blocks
+### Added
+- Added `MAX_SIGNATURE_SEARCH_RANGE` to control the range of the search
+
+### Changed
+- Update `GET: /signatures` to throw when period is invalid.
+
+### Fixed
+- Limit participation rate in `GET: /signatures` to 2 decimal numbers
+- Fix potential division by zero in `countSignatureRate`
 
 ## [4.19.1] - 2022-05-10
 ### Fixed

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -191,6 +191,11 @@ const settings: Settings = {
       apiKey: process.env.RESTRICT_API_KEY as string,
     },
   },
+  signatures: {
+    minSearchRange: 1,
+    maxSearchRange: parseInt(process.env.MAX_SIGNATURE_SEARCH_RANGE || '8', 10),
+    maxSearchRangeInSeconds: parseInt(process.env.MAX_SIGNATURE_SEARCH_RANGE || '8', 10) * 24 * 60 * 60,
+  },
   name: process.env.NEW_RELIC_APP_NAME || process.env.NAME || 'default',
 };
 

--- a/src/config/swagger-internal.json
+++ b/src/config/swagger-internal.json
@@ -362,24 +362,24 @@
     },
     "/signatures": {
       "get": {
-        "summary": "Returns the participation rate of voters in the latest given interval of blocks. If period is not defined, by default it will use today's date -1 day. The period limit is 7 days. If the limit is exceeded in query, the end date - 7 days will be used as default.",
+        "summary": "Returns the participation rate of voters in the latest given interval of blocks.",
         "tags": ["signatures"],
         "parameters": [
           {
             "name": "startDate",
             "in": "query",
-            "description": "The start date of period. This date is inclusive. Date format must be yyyy-mm-dd.",
+            "description": "The start date of period (inclusive). Date format must be yyyy-mm-dd.",
             "required": false,
             "type": "string",
-            "example": "2022-01-01"
+            "example": "2022-02-10"
           },
           {
             "name": "endDate",
             "in": "query",
-            "description": "The end date of period. This date is not inclusive. Date format must be yyyy-mm-dd.",
+            "description": "The end date of period (inclusive). Date format must be yyyy-mm-dd.",
             "required": false,
             "type": "string",
-            "example": "2022-02-01"
+            "example": "2022-02-15"
           }
         ],
         "responses": {
@@ -389,6 +389,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Signatures"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Inserted period is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }

--- a/src/config/swagger.json
+++ b/src/config/swagger.json
@@ -407,24 +407,24 @@
     },
     "/signatures": {
       "get": {
-        "summary": "Returns the participation rate of voters in the latest given interval of blocks. If period is not defined, by default it will use today's date -1 day. The period limit is 7 days. If the limit is exceeded in query, the end date - 7 days will be used as default.",
+        "summary": "Returns the participation rate of voters in the latest given interval of blocks.",
         "tags": ["signatures"],
         "parameters": [
           {
             "name": "startDate",
             "in": "query",
-            "description": "The start date of period. This date is inclusive. Date format must be yyyy-mm-dd.",
+            "description": "The start date of period (inclusive). Date format must be yyyy-mm-dd.",
             "required": false,
             "type": "string",
-            "example": "2022-01-01"
+            "example": "2022-02-10"
           },
           {
             "name": "endDate",
             "in": "query",
-            "description": "The end date of period. This date is not inclusive. Date format must be yyyy-mm-dd.",
+            "description": "The end date of period (inclusive). Date format must be yyyy-mm-dd.",
             "required": false,
             "type": "string",
-            "example": "2022-02-01"
+            "example": "2022-02-15"
           }
         ],
         "responses": {
@@ -434,6 +434,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Signatures"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Inserted period is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }

--- a/src/controllers/SignatureController.ts
+++ b/src/controllers/SignatureController.ts
@@ -1,9 +1,10 @@
 import { inject, injectable } from 'inversify';
 import express, { Request, Response } from 'express';
 
+import settings from '../config/settings';
 import { MetricsQueries } from '../queries/MetricsQueries';
 import { BlockRepository, CountBlocksBetweenProps as Period } from '../repositories/BlockRepository';
-import { getDateOrDefault } from '../utils/time';
+import { createPeriod } from '../utils/period';
 import { countSignatureRate } from '../utils/countSignatureRate';
 
 @injectable()
@@ -17,16 +18,20 @@ class SignatureController {
   }
 
   private getSignatureCount = async (request: Request, response: Response): Promise<void> => {
-    const period = getDateOrDefault(<Period<string>>request.query);
+    try {
+      const period = createPeriod(<Period<string>>request.query, settings.signatures);
 
-    const [amountOfBlocks, voters] = await Promise.all([
-      this.blockRepository.countBlocksFromPeriod(period),
-      this.metricsQueries.getVotersCount(period),
-    ]);
+      const [amountOfBlocks, voters] = await Promise.all([
+        this.blockRepository.countBlocksFromPeriod(period),
+        this.metricsQueries.getVotersCount(period),
+      ]);
 
-    const signatureRate = countSignatureRate(voters, amountOfBlocks);
+      const signatureRate = countSignatureRate(voters, amountOfBlocks);
 
-    response.send(signatureRate);
+      response.send(signatureRate);
+    } catch (e) {
+      response.status(400).send({ error: (<Error>e).message });
+    }
   };
 }
 

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -110,6 +110,11 @@ type Settings = {
       apiKey: string;
     };
   };
+  signatures: {
+    minSearchRange: number;
+    maxSearchRange: number;
+    maxSearchRangeInSeconds: number;
+  };
   name: string;
 };
 

--- a/src/utils/countSignatureRate.ts
+++ b/src/utils/countSignatureRate.ts
@@ -1,9 +1,15 @@
 import { SignatureRate } from '../types/SignatureRate';
 import { TCount } from '../types/analytics/Metrics';
 
+const DEFAULT_PARTICIPATION_RATE = 0;
+
 export const countSignatureRate = (voters: TCount[], numberOfBlocks: number): SignatureRate[] => {
   return voters.map(({ _id, count }) => ({
     _id,
-    participationRate: parseFloat((count / numberOfBlocks).toFixed(2)) * 100,
+    participationRate: calculateParticipationRate(count, numberOfBlocks),
   }));
+};
+
+const calculateParticipationRate = (count: number, numberOfBlocks: number): number => {
+  return numberOfBlocks === 0 ? DEFAULT_PARTICIPATION_RATE : Math.round((count / numberOfBlocks) * 10000) / 100;
 };

--- a/src/utils/period.ts
+++ b/src/utils/period.ts
@@ -1,0 +1,47 @@
+import { CountBlocksBetweenProps as Period } from '../repositories/BlockRepository';
+import { subDays, isValid } from 'date-fns';
+
+interface Config {
+  minSearchRange: number;
+  maxSearchRange: number;
+  maxSearchRangeInSeconds: number;
+}
+
+export const createPeriod = ({ startDate, endDate }: Period<string>, config: Config): Period<Date> => {
+  if (!startDate && !endDate) {
+    return defaultPeriod(config);
+  }
+
+  if (!isValid(new Date(startDate)) || !isValid(new Date(endDate))) {
+    throw new Error('Period is invalid. Format must be yyyy-mm-dd.');
+  }
+
+  const period: Period<Date> = {
+    startDate: new Date(startDate),
+    endDate: new Date(endDate),
+  };
+
+  if (!isPeriodRangeValid(period)) {
+    throw new Error('Period is invalid. startDate must be lower than endDate');
+  }
+
+  if (!isPeriodBelowThreshold(period, config.maxSearchRangeInSeconds)) {
+    throw new Error(`Period range must be lower or equal than ${config.maxSearchRange} days.`);
+  }
+
+  return period;
+};
+
+const defaultPeriod = (config: Config): Period<Date> => ({
+  startDate: subDays(new Date(), config.minSearchRange),
+  endDate: new Date(),
+});
+
+const isPeriodRangeValid = (period: Period<Date>): boolean => {
+  return period.endDate.getTime() > period.startDate.getTime();
+};
+
+const isPeriodBelowThreshold = ({ startDate, endDate }: Period<Date>, threshold: number): boolean => {
+  const currentPeriodTime = endDate.getTime() / 1000 - startDate.getTime() / 1000;
+  return currentPeriodTime < threshold;
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,8 +1,3 @@
-import { CountBlocksBetweenProps as Period } from '../repositories/BlockRepository';
-import { subDays, isValid } from 'date-fns';
-
-const MAX_PERIOD_RANGE = 7;
-const MAX_PERIOD_RANGE_IN_SECONDS = MAX_PERIOD_RANGE * 24 * 60 * 60;
 export const MINUTE = 'm';
 export const HOUR = 'h';
 export const DAY = 'd';
@@ -20,7 +15,7 @@ export const removeMillisecondsFromIsoDate = (date: Date): string => {
   return `${date.toISOString().slice(0, -5)}Z`;
 };
 
-export const getDateAtMidnight = (day: string): Date => {
+export const getDateAtMidnight = (day: string | Date): Date => {
   const date = new Date(day);
 
   date.setUTCHours(0);
@@ -28,34 +23,4 @@ export const getDateAtMidnight = (day: string): Date => {
   date.setUTCSeconds(0);
 
   return date;
-};
-
-export const getDateOrDefault = ({ startDate, endDate }: Period<string>): Period<Date> => {
-  const end = isValid(new Date(endDate)) ? new Date(endDate) : new Date();
-  const start = isValid(new Date(startDate)) ? new Date(startDate) : subDays(end, 1);
-
-  return validatePeriod({ startDate: start, endDate: end });
-};
-
-const validatePeriod = (period: Period<Date>): Period<Date> => {
-  if (isPeriodRangeValid(period) && isPeriodBelowThreshold(period, MAX_PERIOD_RANGE_IN_SECONDS)) {
-    return period;
-  }
-
-  return {
-    startDate: subDays(period.endDate, MAX_PERIOD_RANGE),
-    endDate: period.endDate,
-  };
-};
-
-const isPeriodRangeValid = (period: Period<Date>): boolean => {
-  return period.endDate.getTime() > period.startDate.getTime();
-};
-
-const isPeriodBelowThreshold = (
-  { startDate, endDate }: Period<Date>,
-  threshold = MAX_PERIOD_RANGE_IN_SECONDS
-): boolean => {
-  const currentPeriodTime = endDate.getTime() / 1000 - startDate.getTime() / 1000;
-  return currentPeriodTime < threshold;
 };

--- a/test/e2e/signatures/signatures.e2e.ts
+++ b/test/e2e/signatures/signatures.e2e.ts
@@ -38,65 +38,99 @@ describe('signatures', () => {
   });
 
   describe('GET /signatures', () => {
+    describe('when period is not included in query', () => {
+      it('responds with signature rates on the default period', async () => {
+        const response = await request(app).get('/signatures');
+
+        expect(response.status).to.eq(200);
+        expect(response.body).to.be.an('array').with.length(1);
+      });
+    });
+
     describe('when period query is invalid', () => {
-      describe('when period is not included in query', () => {
-        it('responds with signature rates on the default period', async () => {
-          const response = await request(app).get('/signatures');
+      it('responds with an error message', async () => {
+        const resource = '/signatures?startDate=invalid&endDate=invalid';
+        const response = await request(app).get(resource);
+
+        expect(response.status).to.eq(400);
+        expect(response.body).to.eql({ error: 'Period is invalid. Format must be yyyy-mm-dd.' });
+      });
+    });
+
+    describe('when period query is valid', () => {
+      describe('and the start date is greater than the end date', () => {
+        it('responds with an error message', async () => {
+          const period = {
+            startDate: format(new Date(), 'yyyy-MM-dd'),
+            endDate: format(subDays(new Date(), 5), 'yyyy-MM-dd'),
+          };
+
+          const resource = `/signatures?startDate=${period.startDate}&endDate=${period.endDate}`;
+          const response = await request(app).get(resource);
+
+          expect(response.status).to.eq(400);
+          expect(response.body).to.eql({ error: 'Period is invalid. startDate must be lower than endDate' });
+        });
+      });
+
+      describe('and the range of the period exceeds the configured limit', () => {
+        it('responds with an error message', async () => {
+          const period = {
+            startDate: format(subDays(new Date(), 30), 'yyyy-MM-dd'),
+            endDate: format(new Date(), 'yyyy-MM-dd'),
+          };
+
+          const resource = `/signatures?startDate=${period.startDate}&endDate=${period.endDate}`;
+          const response = await request(app).get(resource);
+
+          expect(response.status).to.eq(400);
+          expect(response.body).to.eql({
+            error: `Period range must be lower or equal than ${settings.signatures.maxSearchRange} days.`,
+          });
+        });
+      });
+
+      describe('and there are blocks in period', () => {
+        it('responds with signature rates on the inserted period', async () => {
+          const period = {
+            startDate: format(subDays(new Date(), 5), 'yyyy-MM-dd'),
+            endDate: format(new Date(), 'yyyy-MM-dd'),
+          };
+
+          const resource = `/signatures?startDate=${period.startDate}&endDate=${period.endDate}`;
+          const response = await request(app).get(resource);
 
           expect(response.status).to.eq(200);
           expect(response.body).to.be.an('array').with.length(1);
         });
       });
 
-      it('responds with signature rates on the default period', async () => {
-        const resource = '/signatures?startDate=invalid&endDate=invalid';
-        const response = await request(app).get(resource);
+      describe('and there are no blocks in period', () => {
+        it('responds with an empty array', async () => {
+          const resource = '/signatures?startDate=1990-05-05&endDate=1990-05-06';
+          const response = await request(app).get(resource);
 
-        expect(response.status).to.eq(200);
-        expect(response.body).to.be.an('array').with.length(1);
-      });
-    });
-
-    describe('when period query is valid', () => {
-      it('responds with signature rates on the inserted period', async () => {
-        const period = {
-          startDate: format(subDays(new Date(), 10), 'yyyy-MM-dd'),
-          endDate: format(new Date(), 'yyyy-MM-dd'),
-        };
-
-        const resource = `/signatures?startDate=${period.startDate}&endDate=${period.endDate}`;
-        const response = await request(app).get(resource);
-
-        expect(response.status).to.eq(200);
-        expect(response.body).to.be.an('array').with.length(1);
-      });
-    });
-
-    describe('when there are no blocks in period', () => {
-      it('responds with an empty array', async () => {
-        const resource = '/signatures?startDate=1990-05-05&endDate=1990-05-06';
-        const response = await request(app).get(resource);
-
-        expect(response.status).to.eq(200);
-        expect(response.body).to.be.an('array').with.length(0);
-      });
-    });
-
-    describe('when there is more than one validator', () => {
-      it('responds with the signature rate of all participants', async () => {
-        await Block.create({
-          ...inputForBlockModel,
-          _id: 'block::4',
-          blockId: 4,
-          dataTimestamp: new Date(),
-          voters: ['0xB205324F4b6EB7Bc76f1964489b3769cfc7144A3'],
-          votes: new Map([['0xB205324F4b6EB7Bc76f1964489b3769cfc7144A3', '10000000000']]),
+          expect(response.status).to.eq(200);
+          expect(response.body).to.be.an('array').with.length(0);
         });
+      });
 
-        const response = await request(app).get('/signatures');
+      describe('and there is more than one validator', () => {
+        it('responds with the signature rate of all participants', async () => {
+          await Block.create({
+            ...inputForBlockModel,
+            _id: 'block::4',
+            blockId: 4,
+            dataTimestamp: new Date(),
+            voters: ['0xB205324F4b6EB7Bc76f1964489b3769cfc7144A3'],
+            votes: new Map([['0xB205324F4b6EB7Bc76f1964489b3769cfc7144A3', '10000000000']]),
+          });
 
-        expect(response.status).to.eq(200);
-        expect(response.body).to.be.an('array').with.length(2);
+          const response = await request(app).get('/signatures');
+
+          expect(response.status).to.eq(200);
+          expect(response.body).to.be.an('array').with.length(2);
+        });
       });
     });
   });

--- a/test/utils/countSignatureRate.test.ts
+++ b/test/utils/countSignatureRate.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { countSignatureRate } from '../../src/utils/countSignatureRate';
+
+describe('countSignatureRate', () => {
+  it('returns the participation rate with at most 2 decimal cases', () => {
+    const numberOfBlocks = 3;
+    const voters = [
+      { _id: '0xABC123', count: 1 },
+      { _id: '0xDEF456', count: 2 },
+      { _id: '0xGHI789', count: 3 },
+      { _id: '0xJKL123', count: 0 },
+    ];
+    const expected = [
+      { _id: '0xABC123', participationRate: 33.33 },
+      { _id: '0xDEF456', participationRate: 66.67 },
+      { _id: '0xGHI789', participationRate: 100 },
+      { _id: '0xJKL123', participationRate: 0 },
+    ];
+
+    const actual = countSignatureRate(voters, numberOfBlocks);
+    expect(actual).to.eql(expected);
+  });
+
+  describe('when no block numbers are found', () => {
+    it('returns a participationRate of zero', () => {
+      const numberOfBlocks = 0;
+      const voters = [{ _id: '0xABC123', count: 10 }];
+      const expected = {
+        _id: '0xABC123',
+        participationRate: 0,
+      };
+
+      const actual = countSignatureRate(voters, numberOfBlocks);
+      expect(actual[0]).to.eql(expected);
+    });
+  });
+});

--- a/test/utils/period.test.ts
+++ b/test/utils/period.test.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import { format, subDays } from 'date-fns';
+
+import settings from '../../src/config/settings';
+import { CountBlocksBetweenProps as Period } from '../../src/repositories/BlockRepository';
+import { createPeriod } from '../../src/utils/period';
+
+describe('createPeriod', () => {
+  const minSearchRange = settings.signatures.minSearchRange;
+  const maxSearchRange = settings.signatures.maxSearchRange;
+  const datePattern = 'yyyy-MM-dd';
+
+  function formatDate(date: Date): string {
+    return format(date, datePattern);
+  }
+
+  function assertPeriod(period: Period<Date>, from: Date, to: Date): void {
+    const { startDate, endDate } = period;
+
+    expect(formatDate(startDate)).to.equal(formatDate(from));
+    expect(formatDate(endDate)).to.equal(formatDate(to));
+  }
+
+  describe('when both start date and end date are not present', () => {
+    it('returns the default period', () => {
+      const expectedEndDate = new Date();
+      const expectedStartDate = subDays(expectedEndDate, minSearchRange);
+
+      const period = createPeriod({ startDate: undefined, endDate: undefined }, settings.signatures);
+
+      assertPeriod(period, expectedStartDate, expectedEndDate);
+    });
+  });
+
+  describe('when both start date and end date are invalid', () => {
+    it('throws an error', () => {
+      const startDate = 'this_date_is_invalid';
+      const endDate = 'this_date_is_invalid';
+
+      try {
+        createPeriod({ startDate, endDate }, settings.signatures);
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.include('Period is invalid. Format must be yyyy-mm-dd.');
+      }
+    });
+  });
+
+  describe('when both start date and end date are valid', () => {
+    describe('and the range of the period is invalid', () => {
+      it('throws an error', () => {
+        const startDate = '2022-05-20';
+        const endDate = '2022-05-10';
+
+        try {
+          createPeriod({ startDate, endDate }, settings.signatures);
+        } catch (e) {
+          expect(e).to.be.instanceOf(Error);
+          expect(e.message).to.include('Period is invalid. startDate must be lower than endDate');
+        }
+      });
+    });
+
+    describe('and period exceeds maximum range', () => {
+      it('throws an error', () => {
+        const startDate = '2022-05-10';
+        const endDate = '2022-05-25';
+
+        try {
+          createPeriod({ startDate, endDate }, settings.signatures);
+        } catch (e) {
+          expect(e).to.be.instanceOf(Error);
+          expect(e.message).to.include(`Period range must be lower or equal than ${maxSearchRange} days.`);
+        }
+      });
+    });
+
+    describe('and period does not exceeds maximum range', () => {
+      it('returns the period with the given dates', () => {
+        const startDate = '2022-05-05';
+        const endDate = '2022-05-10';
+
+        const expectedEndDate = new Date(endDate);
+        const expectedStartDate = new Date(startDate);
+
+        const period = createPeriod({ startDate, endDate }, settings.signatures);
+
+        assertPeriod(period, expectedStartDate, expectedEndDate);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes two issues on the current implementation of signature endpoint:

- Fixed participation rate calculation 
```json
[
  {
    "_id": "0x998cb7821e605cC16b6174e7C50E19ADb2Dd2fB0",
    "participationRate": 100
  },
  {
    "_id": "0xDc3eBc37DA53A644D67E5E3b5BA4EEF88D969d5C",
    "participationRate": 98.95
  }
]
```

- Added `MAX_SIGNATURE_SEARCH_RANGE` to control the range of the search.