### PR TITLE
fix: limit number of candidates for replication to 1K blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [5.2.4] - 2022-10-12
+## [5.2.6] - 2022-10-18
+### Fixed
+- limit number of candidates for replication to 1K blocks
+
+## [5.2.5] - 2022-10-12
 ### Fixed
 - change CI ethereum RPC
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/services/foreign-chain/ForeignBlockReplicator.ts
+++ b/src/services/foreign-chain/ForeignBlockReplicator.ts
@@ -205,6 +205,7 @@ export abstract class ForeignBlockReplicator implements IForeignBlockReplicator 
       dataTimestamp: { $gt: dataTimestamp },
     })
       .sort({ blockId: -1 })
+      .limit(1000) // arbitrary value, we should not be that many blocks behind unless this is new blockchain
       .exec();
 
     if (candidates.length == 0) {


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev
- [x] Tested on sbx
- [x] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [x] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [x] **there are no errors in logs in any workers**
- [x] new blocks are being discovered and marked as finalized
- [x] foreign blocks are being replicated
- [ ] FCDs are updated to the newest values 
- [x] squash all commits before merging
