### PR TITLE
feat: RPC calls optimisation: save last scanned block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [5.7.0] - 2023-02-28
+### Changed
+- RPC calls optimisation: save last scanned block
+
+### Fixed
+- override value of `block.number` for Arbitrum, to be Arbitrum blockchain number
+
 ## [5.6.0] - 2023-02-16
 ### Changed
 - replicate most recent block

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/constants/mappings.ts
+++ b/src/constants/mappings.ts
@@ -1,0 +1,4 @@
+export const LAST_BLOCK_CHECKED_FOR_NEW_CHAIN = (chainId: string | number): string =>
+  `LAST_BLOCK_CHECKED_FOR_NEW_CHAIN__${chainId}`;
+export const LAST_BLOCK_CHECKED_FOR_MINT_EVENT = (chainId: string | number): string =>
+  `LAST_BLOCK_CHECKED_FOR_MINT_EVENT__${chainId}`;

--- a/src/contracts/BaseChainContract.ts
+++ b/src/contracts/BaseChainContract.ts
@@ -1,5 +1,5 @@
 import { inject } from 'inversify';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { ABI, LeafKeyCoder } from '@umb-network/toolbox';
 import { Logger } from 'winston';
 
@@ -48,6 +48,11 @@ export abstract class BaseChainContract {
         status[key] = chainContractStatus[key];
       }
     });
+
+    if (this.blockchain.chainId === ChainsIds.ARBITRUM) {
+      // block.number on arbitrum is ethereum block number, so we need to override
+      status.blockNumber = BigNumber.from(await this.blockchain.getBlockNumber());
+    }
 
     return { chainAddress: chain.contract.address, ...status };
   }

--- a/src/lib/Blockchain.ts
+++ b/src/lib/Blockchain.ts
@@ -10,7 +10,7 @@ export class Blockchain {
   readonly chainId!: string;
   readonly isHomeChain!: boolean;
   readonly settings!: BlockchainSettings;
-  readonly provider: ethers.providers.Provider;
+  readonly provider: ethers.providers.StaticJsonRpcProvider;
   readonly wallet: Wallet;
 
   constructor(props: BlockchainProps) {
@@ -30,7 +30,7 @@ export class Blockchain {
       throw Error(`missing contractRegistryAddress for ${chainId}`);
     }
 
-    this.provider = ethers.providers.getDefaultProvider(this.settings.providerUrl);
+    this.provider = new ethers.providers.StaticJsonRpcProvider(this.settings.providerUrl);
 
     if (settings.blockchain.replicatorPrivateKey) {
       this.wallet = new Wallet(settings.blockchain.replicatorPrivateKey, this.provider);

--- a/src/models/Mapping.ts
+++ b/src/models/Mapping.ts
@@ -1,0 +1,13 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IMapping extends Document {
+  _id: string;
+  value: string;
+}
+
+const MappingSchema: Schema = new Schema({
+  _id: { type: String, required: true },
+  value: { type: String, required: true, unique: false },
+});
+
+export default mongoose.model<IMapping>('Mapping', MappingSchema);

--- a/src/repositories/MappingRepository.ts
+++ b/src/repositories/MappingRepository.ts
@@ -1,0 +1,27 @@
+import { injectable } from 'inversify';
+import Mapping from '../models/Mapping';
+
+@injectable()
+export class MappingRepository {
+  async get(_id: string): Promise<string | undefined> {
+    const map = await Mapping.findOne({ _id }).exec();
+    return map?.value;
+  }
+
+  async getMany(keys: string[]): Promise<Record<string, string>> {
+    const map = await Mapping.find({ _id: { $in: keys } }).exec();
+
+    return map.reduce((acc, data) => {
+      acc[data._id] = data.value;
+      return acc;
+    }, {} as Record<string, string>);
+  }
+
+  async set(_id: string, value: string): Promise<void> {
+    await Mapping.findOneAndUpdate({ _id }, { _id, value }, { upsert: true, new: true }).exec();
+  }
+
+  async setMany(data: { _id: string; value: string }[]): Promise<void> {
+    await Promise.all(data.map(({ _id, value }) => this.set(_id, value)));
+  }
+}

--- a/src/services/BlockSynchronizer.ts
+++ b/src/services/BlockSynchronizer.ts
@@ -122,9 +122,9 @@ class BlockSynchronizer {
 
     const chain = <ChainContract>this.chainContractRepository.get(chainId);
 
-    const [chainStatus, [lastSavedBlockId]] = await Promise.all([
+    const [chainStatus, lastSavedBlockId] = await Promise.all([
       chain.resolveStatus<ChainStatus>(),
-      this.latestIdsProvider.getLastSavedBlockIdAndStartAnchor(chainId),
+      this.latestIdsProvider.getLastSavedBlockId(chainId),
     ]);
 
     this.logger.debug(`[${chainId}] checkForRevertedBlocks: ${JSON.stringify(chainStatus)}`);

--- a/src/services/LatestIdsProvider.ts
+++ b/src/services/LatestIdsProvider.ts
@@ -6,14 +6,14 @@ import { ChainsIds } from '../types/ChainsIds';
 
 @injectable()
 export class LatestIdsProvider {
-  getLastSavedBlockIdAndStartAnchor = async (
-    chainId: ChainsIds
-  ): Promise<[lastSavedBlockId: number, lastAnchor: number]> => {
+  getLastSavedBlockId = async (chainId: ChainsIds): Promise<number> => {
     const lastSavedBlock = await BlockChainData.find({ chainId: chainId }).sort({ blockId: -1 }).limit(1).exec();
+    return lastSavedBlock[0] ? lastSavedBlock[0].blockId : 0;
+  };
 
-    return lastSavedBlock[0]
-      ? [lastSavedBlock[0].blockId, lastSavedBlock[0].anchor + 1]
-      : [0, await this.getLowestChainAnchor(chainId)];
+  getLastAnchor = async (chainId: ChainsIds): Promise<number> => {
+    const lastSavedBlock = await BlockChainData.find({ chainId: chainId }).sort({ blockId: -1 }).limit(1).exec();
+    return lastSavedBlock[0] ? lastSavedBlock[0].anchor + 1 : await this.getLowestChainAnchor(chainId);
   };
 
   private getLowestChainAnchor = async (chainId: ChainsIds): Promise<number> => {

--- a/src/services/foreign-chain/ForeignBlockReplicator.ts
+++ b/src/services/foreign-chain/ForeignBlockReplicator.ts
@@ -69,6 +69,7 @@ export abstract class ForeignBlockReplicator implements IForeignBlockReplicator 
     this.homeChainContract = <ChainContract>(
       this.chainContractRepository.get(this.settings.blockchain.homeChain.chainId)
     );
+
     this.foreignChainContract = <ForeignChainContract>this.chainContractRepository.get(this.chainId);
   }
 

--- a/test/services/BlockSynchronizer.test.ts
+++ b/test/services/BlockSynchronizer.test.ts
@@ -81,7 +81,7 @@ describe('BlockSynchronizer', () => {
   let blockchainRepository: SinonStubbedInstance<BlockchainRepository>;
   let chainContract: SinonStubbedInstance<ChainContract>;
   let chainContractRepository: SinonStubbedInstance<ChainContractRepository>;
-  let provider: StubbedInstance<ethers.providers.Provider>;
+  let provider: StubbedInstance<ethers.providers.StaticJsonRpcProvider>;
 
   describe('#apply', async () => {
     const resolveChainStatus = async (blockNumber: BigNumber, lastBlockId = 10, nextBlockId = 10) =>
@@ -108,7 +108,7 @@ describe('BlockSynchronizer', () => {
       blockchainRepository = createStubInstance(BlockchainRepository);
       chainContract = createStubInstance(ChainContract);
       chainContractRepository = createStubInstance(ChainContractRepository);
-      provider = createStubInstance(ethers.providers.Provider);
+      provider = createStubInstance(ethers.providers.StaticJsonRpcProvider);
       wallet = Wallet.createRandom();
 
       revertedBlockResolver.apply.resolves(0);

--- a/test/services/ForeignChainReplicator.test.ts
+++ b/test/services/ForeignChainReplicator.test.ts
@@ -40,7 +40,7 @@ describe('ForeignChainReplicator', () => {
   let blockChainData: StubbedInstance<IBlockChainData>;
   let blockchainRepository: StubbedInstance<BlockchainRepository>;
   let chainContractRepository: StubbedInstance<ChainContractRepository>;
-  let provider: StubbedInstance<ethers.providers.Provider>;
+  let provider: StubbedInstance<ethers.providers.StaticJsonRpcProvider>;
 
   after(() => {
     sinon.restore();
@@ -57,7 +57,7 @@ describe('ForeignChainReplicator', () => {
         arbitrumBlockReplicator = stubConstructor(ArbitrumBlockReplicator);
         blockchainRepository = createStubInstance(BlockchainRepository);
         chainContractRepository = createStubInstance(ChainContractRepository);
-        provider = createStubInstance(ethers.providers.Provider);
+        provider = createStubInstance(ethers.providers.StaticJsonRpcProvider);
         wallet = Wallet.createRandom();
         sinon.stub(wallet, 'getBalance').resolves(parseEther('1'));
 
@@ -129,7 +129,7 @@ describe('ForeignChainReplicator', () => {
         polygonBlockReplicator = stubConstructor(PolygonBlockReplicator);
         arbitrumBlockReplicator = stubConstructor(ArbitrumBlockReplicator);
         blockchainRepository = createStubInstance(BlockchainRepository);
-        provider = createStubInstance(ethers.providers.Provider);
+        provider = createStubInstance(ethers.providers.StaticJsonRpcProvider);
 
         wallet = Wallet.createRandom();
         sinon.stub(wallet, 'getBalance').resolves(parseEther('0.001'));


### PR DESCRIPTION
## [5.7.0] - 2023-02-28
### Changed
- RPC calls optimisation: save last scanned block
- use `StaticJsonRpcProvider`

### Fixed
- override value of `block.number` for Arbitrum, to be Arbitrum blockchain number

## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev
- [ ] Tested on sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being replicated
- [ ] FCDs are updated to the newest values 
- [ ] squash all commits before merging
