### PR TITLE
patch: use newest ABI for arbitrum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [5.7.2] - 2023-03-02
+### Changed
+- use newest ABI for arbitrum
+
 ## [5.7.1] - 2023-03-02
 ### Fixed
 - handle error: `requested to block N after last accepted block N-1`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/contracts/BaseChainContract.ts
+++ b/src/contracts/BaseChainContract.ts
@@ -78,7 +78,11 @@ export abstract class BaseChainContract {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected chainAbi = (): any => {
-    if ([ChainsIds.AVALANCHE, ChainsIds.POLYGON, ChainsIds.BSC].includes(this.blockchain.chainId as ChainsIds)) {
+    if (
+      [ChainsIds.AVALANCHE, ChainsIds.POLYGON, ChainsIds.BSC, ChainsIds.ARBITRUM].includes(
+        this.blockchain.chainId as ChainsIds
+      )
+    ) {
       return newAbi;
     }
 


### PR DESCRIPTION
## Context

Use multichain ABI for Arbitrum

## To-do list

- [ ] Added tests
- [ ] Tested on dev
- [ ] Tested on sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being replicated
- [ ] FCDs are updated to the newest values 
- [ ] squash all commits before merging
