### PR TITLE
fix: use proper `warn` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [5.10.7] - 2024-03-12
+### Fixed
+- use proper `warn` method
+
 ## [5.10.6] - 2024-03-07
 ### Fixed
 - fix settings for blockchainScanner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "5.10.6",
+  "version": "5.10.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/controllers/OnChainReportsController.ts
+++ b/src/controllers/OnChainReportsController.ts
@@ -84,10 +84,10 @@ export class OnChainReportsController {
     const chainId = request.params.chainId as ChainsIds;
     const key = request.params.key;
     let days = parseInt(request.params.days || '3');
-    const daysLimit = 30;
+    const daysLimit = 365;
 
     if (days > daysLimit) {
-      this.logger.warning(`[priceHistory][${chainId}] days limit is ${daysLimit}`);
+      this.logger.warn(`[priceHistory][${chainId}] days limit is ${daysLimit}`);
       days = daysLimit;
     }
 


### PR DESCRIPTION
## [5.10.7] - 2024-03-12
### Fixed
- use proper `warn` method