### PR TITLE
fix `prevPrice` in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [5.11.1] - 2024-03-13
+### Fixed
+- fix `prevPrice` in reports
+
 ## [5.11.0] - 2024-03-13
 ### Updated
 - include tx cost and the number of feeds updated in each tx in reports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/controllers/OnChainReportsController.ts
+++ b/src/controllers/OnChainReportsController.ts
@@ -188,7 +188,7 @@ export class OnChainReportsController {
     results.push(Object.values(historyReportLabels).join(separator));
 
     let prev = {
-      ...feedsHistory[feedsHistory.length > 0 ? 1 : 0],
+      ...feedsHistory[feedsHistory.length > 1 ? 1 : 0],
     };
 
     const txMap = await this.getTxMap(chainId, feedsHistory);


### PR DESCRIPTION
## [5.11.1] - 2024-03-13
### Fixed
- fix `prevPrice` in reports