### PR TITLE
change timeout for fetching blocks to 25s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [5.13.1] - 2025-03-03
+### Changed
+- change timeout for fetching blocks to 25s
+
 ## [5.13.0] - 2024-12-13
 ### Added
 - add support for `5ire` expenses reports 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanctuary",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umbrella-network/sanctuary.git"

--- a/src/services/on-chain-stats/EvmTxsFetcher.ts
+++ b/src/services/on-chain-stats/EvmTxsFetcher.ts
@@ -32,8 +32,10 @@ export class EvmTxsFetcher {
 
     this.logger.debug(`${chainId}[EvmTxsFetcher] fetching txs for ${arr.length} blocks`);
 
+    const arrSorted = arr.sort();
+
     const allTxsSettled = await Promise.allSettled(
-      arr.sort().map((i) => promiseWithTimeout(provider.getBlockWithTransactions(i), 15000))
+      arrSorted.map((i) => promiseWithTimeout(provider.getBlockWithTransactions(i), 25000))
     );
 
     let errorDetected = false;
@@ -47,7 +49,7 @@ export class EvmTxsFetcher {
       }
 
       errorDetected = true;
-      this.logger.error(`${chainId} block ${arr[i]} error: ${result.reason.toString()}`);
+      this.logger.error(`${chainId} block ${arrSorted[i]} error: ${result.reason.toString()}`);
       return undefined;
     });
 


### PR DESCRIPTION
## Context

<!-- Add a brief description of your changes -->

## To-do list

- [ ] Added tests
- [ ] Tested on dev
- [ ] Tested on sbx
- [ ] Changelog was updated with current changes
- [ ] Documentation or guides were updated (slab, readme)
- [ ] Version was updated on `package.json` (releases/hotfixes)

## Checklist before merge

- [ ] **there are no errors in logs in any workers**
- [ ] new blocks are being discovered and marked as finalized
- [ ] foreign blocks are being replicated
- [ ] FCDs are updated to the newest values 
- [ ] squash all commits before merging
